### PR TITLE
【Fixed】#21 SNSログインした場合のパスワードの扱いを変更する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
   mount_uploader :avatar, AvatarUploader
-  
+
   def self.create_unique_string
    SecureRandom.uuid
   end
@@ -46,6 +46,15 @@ class User < ActiveRecord::Base
       user.save
     end
     user
+  end
+
+  def update_with_password(params, *options)
+    if provider.blank?
+      super
+    else
+      params.delete :current_password
+      update_without_password(params, *options)
+    end
   end
 
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -14,28 +14,32 @@
     <%= f.text_field :name, class: "form-control" %>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+  <% if @user.provider.blank? %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "off" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
     <% end %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
+    <div class="field">
+      <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+      <%= f.password_field :password, autocomplete: "off" %>
+      <% if @minimum_password_length %>
+        <br />
+        <em><%= @minimum_password_length %> characters minimum</em>
+      <% end %>
+    </div>
 
-  <div class="field">
-    <%= f.label :現在のパスワード %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "off", class:"form-control" %>
-  </div>
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "off" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :現在のパスワード %> <i>(we need your current password to confirm your changes)</i><br />
+      <%= f.password_field :current_password, autocomplete: "off", class:"form-control" %>
+    </div>
+
+  <% end %>
 
   <div class="field">
     <%= profile_img(@user) if profile_img(@user) %>


### PR DESCRIPTION
#13 

Userのproviderが空でない場合、以下の対応を行う

- [ ] パスワードなしでユーザー情報を変更できるようにする
      app/models/user.rbを編集
      update_with_passwordをオーバーライドする

- [ ] ユーザー情報編集でパスワード欄を非表示とする
      app/views/devise/registrations/edit.html.erbを編集