### PR TITLE
【Developing】#31 ユーザー詳細ページからタブ形式で同一ページに表示する

### DIFF
--- a/app/views/users/_followed_user.html.erb
+++ b/app/views/users/_followed_user.html.erb
@@ -1,0 +1,6 @@
+<% user.followed_users.each do |user| %>
+  <div class="col-md-6 col-xs-12">
+    <%= profile_img(user) %>
+    <%= user.name %>さん
+  </div>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,3 +14,25 @@
     </div>
   </div>
 </div>
+
+<ul class="nav nav-tabs">
+	<li><a href="#sampleContentA" data-toggle="tab">ツイート</a></li>
+	<li class="active"><a href="#sampleContentB" data-toggle="tab">フォロー</a></li>
+	<li><a href="#sampleContentC" data-toggle="tab">フォロワー</a></li>
+	<li><a href="#sampleContentD" data-toggle="tab">お気に入り</a></li>
+</ul>
+
+<div class="tab-content">
+	<div class="tab-pane" id="sampleContentA">
+		<p>タブＡの内容</p>
+	</div>
+	<div class="tab-pane active" id="sampleContentB">
+		<%= render 'followed_user', user: @user%>
+	</div>
+	<div class="tab-pane" id="sampleContentC">
+		<p>タブＣの内容</p>
+	</div>
+	<div class="tab-pane" id="sampleContentD">
+		<p>タブＤの内容</p>
+	</div>
+</div>


### PR DESCRIPTION
#58 
サンプルでusers/showにタブ形式で同一ページに表示出来るよう実装しました。
※フォローしているユーザーをタブで見れます。

実装イメージが合えば、その他も同様に実装していきます。
ご確認よろしくお願いします。
